### PR TITLE
Changed identityHashCode argument for ViewPlants

### DIFF
--- a/src/plantTracker/ViewPlants.java
+++ b/src/plantTracker/ViewPlants.java
@@ -58,7 +58,7 @@ class ViewPlants {
 		// For testing purposes. Comment out or delete if desired.
 		System.out.println("vBox.isResizable(): " + vBox.isResizable());
 		System.out.println("Called: this.ViewPlant.display() | " + 
-							"Hash Code: " + System.identityHashCode(getClass()));
+							"Hash Code: " + System.identityHashCode(this));
 	}
 	
 	private void add(String name) {


### PR DESCRIPTION
I don't know if these print statments will be useful, but I just noticed that I meant to put System.identityHashCode(this) and not System.identityHashCode(getClass()) when reviewing the code.